### PR TITLE
Fix #8: Publish release artifacts to bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Sparrow is a Scala library for converting Spark Dataframe rows to case classes.
 
 [![Build Status](https://travis-ci.org/ypg-data/sparrow.svg)](https://travis-ci.org/ypg-data/sparrow)
 [![Join the chat at https://gitter.im/ypg-data/sparrow](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ypg-data/sparrow)
+[![Download latest version](https://api.bintray.com/packages/ypg-data/sparrow/sparrow/images/download.svg)](https://bintray.com/ypg-data/sparrow/sparrow/_latestVersion)
 
 ## Status
 
@@ -49,6 +50,12 @@ For code contributions, these are the suggested steps:
  - Create a pull request.
  - Address any issues raised during the code review.
  - Once you get a "+1" on the pull request, the change can be merged.
+
+## Releasing
+
+Once you've tagged a version run the following command to publish:
+
+    $ sbt publish core/bintrayRemoteSign
 
 ## License
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,22 @@ lazy val commonSettings = Seq(
   fork in Test := true
 )
 
+lazy val noPublishSettings = Seq(
+  publish := (),
+  publishLocal := (),
+  publishArtifact := false
+)
+
+lazy val publishSettings = Seq(
+  homepage := Some(url("https://github.com/ypg-data/sparrow")),
+  apiURL := Some(url("https://ypg-data.github.io/sparrow/api/")),
+  autoAPIMappings := true,
+  publishArtifact in Test := false,
+  publishMavenStyle := false,
+  bintrayRepository := "sparrow",
+  bintrayOrganization := Some("ypg-data")
+)
+
 // Scala style guide: https://github.com/daniel-trinh/scalariform#scala-style-guide
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
    .setPreference(DoubleIndentClassDeclaration, true)
@@ -67,10 +83,18 @@ def sparkLibs(scalaVersion: String) = {
   )
 }
 
+lazy val root = (project in file("."))
+  .settings(
+    name := "sparrow-project",
+    noPublishSettings
+  )
+  .aggregate(core)
+
 lazy val core = project
   .settings(
     name := "sparrow",
     commonSettings,
+    publishSettings,
     defaultScalariformSettings,
     libraryDependencies ++= scalaTest ++ sparkLibs(scalaVersion.value) ++ Seq(
       "com.typesafe.play"      %% "play-functional" % "2.4.0-RC1",


### PR DESCRIPTION
For now the process of publishing a new version is manual and described
in the README. This should be done automatically via a future
integration with `sbt-release`.

This also introduces a root project in order to exclude it from being
published and changes projects to use `moduleName` instead of `name`,
which seems more standard.

Example of published files can be found here: https://bintray.com/ypg-data/sparrow/sparrow/view#files