### PR TITLE
Publish to common Bintray ypg-data/ivy-releases repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ For code contributions, these are the suggested steps:
 To release version `x.y.z` run:
 
     $ sbt release -Dversion=x.y.z
+    $ sbt ++2.11.7 publish
 
-This will take care of running tests, tagging and publishing JARs and API docs.
+This will take care of running tests, tagging and publishing JARs and API docs
+for both version 2.10 and 2.11.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tests](https://github.com/ypg-data/sparrow/tree/master/core/src/test/scala/com.m
 
 To use the libray in an SBT project add the following two project settings:
 
-    resolvers += Resolver.url("Sparrow Releases", url("https://dl.bintray.com/ypg-data/sparrow"))(Resolver.ivyStylePatterns)
+    resolvers += Resolver.url("Sparrow Releases", url("https://dl.bintray.com/ypg-data/ivy-releases"))(Resolver.ivyStylePatterns)
     libraryDependencies += "com.mediative" %% "sparrow" % "0.1.0"
 
 ## Building and Testing

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val publishSettings = Seq(
   autoAPIMappings := true,
   publishArtifact in Test := false,
   publishMavenStyle := false,
-  bintrayRepository := "sparrow",
+  bintrayRepository := "ivy-releases",
   bintrayOrganization := Some("ypg-data")
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-//resolvers += "typesafe maven" at "http://repo.typesafe.com/typesafe/maven-releases"
-
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+resolvers += Resolver.url("SBT Plugin Releases", url("https://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"    % "0.4.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-scalariform"  % "1.3.0")


### PR DESCRIPTION
This seems to be the standard way to indicate that a repository is
structured using Ivy-style layout. On the Bintray side it has the type
"Generic".