### PR TITLE
Timestamp type

### DIFF
--- a/core/src/test/scala/com.mediative.sparrow/DataFrameReaderTest.scala
+++ b/core/src/test/scala/com.mediative.sparrow/DataFrameReaderTest.scala
@@ -16,7 +16,6 @@
 
 package com.mediative.sparrow
 
-import java.sql.Timestamp
 import scala.reflect.ClassTag
 
 import scalaz._
@@ -97,26 +96,11 @@ object DataFrameReaderTest {
   }
 }
 
-/*
-By design, toRDD requires the classes it works on to take at least two
-public constructor arguments.
-*/
-object TestCaseClasses {
-  @schema(equal = RowConverter.lenientEqual)
-  case class TestToRdd1(intVal: Int, stringVal: String)
-
-  @schema(equal = RowConverter.lenientEqual)
-  case class TestToRdd2(intVal: Int, intOptionVal: Option[Int])
-
-  @schema(equal = RowConverter.lenientEqual)
-  case class TestToRdd3(stringVal: String, timestampVal: Timestamp)
-}
-
 class DataFrameReaderTest extends FreeSpec with BeforeAndAfterAll {
+
   import DataFrameReaderTest._
 
   val sc = new SparkContext("local", "test2")
-  val sqlContext = new SQLContext(sc)
 
   override def afterAll() = sc.stop()
 
@@ -161,6 +145,7 @@ class DataFrameReaderTest extends FreeSpec with BeforeAndAfterAll {
     import DataFrameReader._
 
     def testSuccess[T: RowConverter: ClassTag](json: Array[String], expected: List[T]) = {
+      val sqlContext = new SQLContext(sc)
       val df = sqlContext.jsonRDD(sc.parallelize(json))
       val rdd = toRDD[T](df).valueOr { es => fail((es.head :: es.tail).mkString("\n")) }
 
@@ -168,56 +153,10 @@ class DataFrameReaderTest extends FreeSpec with BeforeAndAfterAll {
     }
 
     def testFailure[T: RowConverter: ClassTag](json: Array[String], expected: NonEmptyList[String]) = {
+      val sqlContext = new SQLContext(sc)
       val df = sqlContext.jsonRDD(sc.parallelize(json))
 
       assert(toRDD[T](df) == expected.failure)
-    }
-
-    // To get DataFrame#toRDD usage.
-    import com.mediative.sparrow.syntax.df._
-
-    "round-trip an object containing an Int and a String from RDD to DataFrame back to RDD" in {
-      import TestCaseClasses.TestToRdd1
-
-      val expected = TestToRdd1(1, "a")
-      val df = sqlContext.createDataFrame(sc.parallelize(List(expected)))
-
-      assert(df.toRDD[TestToRdd1].toOption.get.first == expected)
-    }
-
-    "round-trip an object containing an Int and an optional Int from RDD to DataFrame back to RDD" - {
-      "when containing some value" in {
-        import TestCaseClasses.TestToRdd2
-
-        val expected = TestToRdd2(1, Option(1))
-        val df =
-          sqlContext.createDataFrame(sc.parallelize(List(expected)))
-
-        assert(df.toRDD[TestToRdd2].toOption.get.first == expected)
-      }
-
-      "when containing no value" in {
-        import TestCaseClasses.TestToRdd2
-
-        val expected = TestToRdd2(1, Option.empty)
-        val df =
-          sqlContext.createDataFrame(sc.parallelize(List(expected)))
-
-        assert(df.toRDD[TestToRdd2].toOption.get.first == expected)
-      }
-    }
-
-    "round-trip an object containing a String and a Timestamp from RDD to DataFrame back to RDD" in {
-      import TestCaseClasses.TestToRdd3
-
-      val expected =
-        TestToRdd3("a", Timestamp.valueOf("2015-07-15 09:00:00"))
-
-      val df =
-        sqlContext.createDataFrame(sc.parallelize(List(expected)))
-
-        pendingUntilFixed(
-          assert(df.toRDD[TestToRdd3].toOption.get.first == expected))
     }
 
     "work for simple case class with only primitives" in {

--- a/core/src/test/scala/com.mediative.sparrow/DateTimeOptionsSpec.scala
+++ b/core/src/test/scala/com.mediative.sparrow/DateTimeOptionsSpec.scala
@@ -108,20 +108,7 @@ class DateTimeOptionsSpec extends FreeSpec {
     "should support the timestamp type of Spark to a sql timestamp." in {
       implicit val _ = tpeFromTimestamp
       val now = new Timestamp(System.currentTimeMillis)
-      pendingUntilFixed {
-        test(Row("Hello", now), TimeStampHolder("Hello", now))
-      }
-    }
-
-    "should support the timestamp type of Spark to a joda time DateTime." in {
-      implicit val _: Tpe[DateTimeHolder] = StructType(List(
-        StructField("name", StringType, nullable = false),
-        StructField("dateTime", StringType, nullable = false)
-      ))
-      val now = DateTime.now
-      pendingUntilFixed {
-        test(Row("Hello", new Timestamp(now.getMillis)), DateTimeHolder("Hello", now))
-      }
+      test(Row("Hello", now), TimeStampHolder("Hello", now))
     }
   }
 }


### PR DESCRIPTION
- Updated the timestamp converter to support either a long type as input or Spark's timestamp.
- Replaced the unit tests from  `DataFrameReaderTest` by tests in the spec related to dates, using directly `java.sql.Timestamp` in a Spark's `Row`.