### PR TITLE
Use default sbt-spark-package spIncludeMaven setting value

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,6 @@ lazy val sparkPackagesSettings = Seq(
   sparkVersion := "1.3.1",
   sparkComponents += "sql",
   spAppendScalaVersion := true,
-  spIncludeMaven := true,
   credentials += Credentials(Path.userHome / ".credentials" / "spark-packages.properties")
 )
 


### PR DESCRIPTION
Remove `spIncludeMaven` from `sparkPackagesSettings`. It's `false` by
default, which means that Sparrow is not available on Maven Central.

Fixes publishing of Spark Package via `spPublish`.