### PR TITLE
Configure Travis to share Ivy cache across builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use container-based infrastructure
+sudo: false
+
 language: scala
 
 scala:
@@ -8,6 +11,19 @@ scala:
 jdk:
   - openjdk7
   - oraclejdk8
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
+# These directories are cached at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
 
 notifications:
   webhooks:


### PR DESCRIPTION
Speed up builds by caching the ~/.ivy and ~/.sbt directories as
documented here:

 - http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache